### PR TITLE
intel-feat: Implement folder route for /realty and remove basePath

### DIFF
--- a/app/realty/page.tsx
+++ b/app/realty/page.tsx
@@ -1,0 +1,9 @@
+export default function RealtyPage() {
+  return (
+    <div>
+      <h1>Welcome to Realty!</h1>
+      <p>This is the realty page.</p>
+    </div>
+  );
+}
+

--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,5 @@
 const nextConfig = {
-  basePath: '/realty',
+
 
 };
 

--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,6 @@
 import type { NextConfig } from 'next';
 
-const nextConfig: NextConfig = {
+const nextConfig = {
   basePath: '/realty',
   async redirects() {
     return [

--- a/next.config.js
+++ b/next.config.js
@@ -1,16 +1,6 @@
-import type { NextConfig } from 'next';
-
 const nextConfig = {
   basePath: '/realty',
-  async redirects() {
-    return [
-      {
-        source: '/',
-        destination: '/realty',
-        permanent: true,
-      },
-    ];
-  },
+
 };
 
 module.exports = nextConfig;


### PR DESCRIPTION
This PR removes the basePath configuration from next.config.js and implements a folder-based route for /realty by creating app/realty/page.tsx. This should resolve the 404 error for the /realty route.