### PR TITLE
fix: Remove --turbopack from build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",
-    "build": "next build --turbopack",
+    "build": "next build",
     "start": "next start",
     "lint": "eslint"
   },


### PR DESCRIPTION
This PR removes the --turbopack flag from the build script in package.json to resolve Vercel deployment errors.