### PR TITLE
fix: ESLint error in contact route (nodemailer typing)

### DIFF
--- a/app/api/contact/route.ts
+++ b/app/api/contact/route.ts
@@ -114,7 +114,7 @@ export async function POST(request: NextRequest) {
     if (process.env.SMTP_HOST && (process.env.CONTACT_TO || process.env.BUSINESS_EMAIL)) {
       try {
         const nodemailer = await import('nodemailer');
-        const transporter = (nodemailer as any).createTransport({
+        const transporter = nodemailer.default.createTransport({
           host: process.env.SMTP_HOST,
           port: parseInt(process.env.SMTP_PORT || '587', 10),
           secure: process.env.SMTP_PORT === '465',


### PR DESCRIPTION
## Problem
The latest deployment to Vercel failed with an ESLint error:
```
./app/api/contact/route.ts
117:44  Error: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
```

## Solution
Replaced `(nodemailer as any).createTransport` with `nodemailer.default.createTransport` to properly access the default export without using the `any` type.

## Testing
- ✅ Local build passes cleanly with all 23 routes generated
- ✅ No ESLint errors
- ✅ TypeScript compilation successful

## Impact
- Fixes Vercel deployment failure
- Maintains proper type safety
- No functional changes to the contact form API